### PR TITLE
change mmc governor to performance mode

### DIFF
--- a/recipes-bsp/startup-scripts/files/99-mmc2-governor.rules
+++ b/recipes-bsp/startup-scripts/files/99-mmc2-governor.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="devfreq", KERNEL=="mmc2", ATTR{governor}="performance"

--- a/recipes-bsp/startup-scripts/sdcard-scripts-automount.bb
+++ b/recipes-bsp/startup-scripts/sdcard-scripts-automount.bb
@@ -7,6 +7,7 @@ DESCRIPTION = "Script for automounting SD Card"
 SRC_URI += "\
             file://automountsdcard.sh \
             file://automountsdcard.rules \
+            file://99-mmc2-governor.rules \
             file://sdcardmount@.service \
 "
 
@@ -25,8 +26,10 @@ do_install() {
         sed -i "s/SLOT/"\"${SDCARD_DEVICE}\""/g" ${WORKDIR}/automountsdcard.rules
         install -d 0644 ${D}${sysconfdir}/udev/rules.d
         install -m 0744 ${WORKDIR}/automountsdcard.rules ${D}${sysconfdir}/udev/rules.d/
-	install -d 0644 ${D}${systemd_unitdir}/system
-	install -m 0644 ${WORKDIR}/sdcardmount@.service ${D}${systemd_unitdir}/system
+        install -m 0744 ${WORKDIR}/99-mmc2-governor.rules ${D}${sysconfdir}/udev/rules.d/
+        install -d 0644 ${D}${systemd_unitdir}/system
+        install -m 0644 ${WORKDIR}/sdcardmount@.service ${D}${systemd_unitdir}/system
+
     else
         install -d ${D}${sysconfdir}/mdev
         install -m 0755 ${WORKDIR}/automountsdcard.sh ${D}${sysconfdir}/mdev/


### PR DESCRIPTION
 * The performance governor mode will keep the device running at its highest frequency at all times.